### PR TITLE
Strip trailing chars was editing . to - as well

### DIFF
--- a/scripts/fix-onedrive-filenames-apfs.sh
+++ b/scripts/fix-onedrive-filenames-apfs.sh
@@ -92,7 +92,7 @@ fix_trailing_chars() {
 		line="$(sed -n "${counter}"p "$fixtrail")"
 		name="$(basename "$line")"
 		path="$(dirname "$line")"
-		fixedname="$(echo "$name" | tr '.' '-' | awk '{sub(/[ \t]+$/, "")};1')"
+		fixedname="$(echo "$name" | awk '{sub(/[ \t]+$/, "")};1')"
 
 		if [[ -f "$path"'/'"$fixedname" ]] || [[ -d "$path"'/'"$fixedname" ]]; then
 


### PR DESCRIPTION
strip_trailing_chars was removing '.' from filenames
i.e. "This file.txt " renamed to "This file-txt"