### PR TITLE
Bugfix: Strip leading spaces was too greedy.

### DIFF
--- a/scripts/fix-onedrive-filenames-apfs.sh
+++ b/scripts/fix-onedrive-filenames-apfs.sh
@@ -118,7 +118,7 @@ fix_leading_spaces() {
 		line="$(sed -n "${counter}"p "$fixlead")"
 		name="$(basename "$line")"
 		path="$(dirname "$line")"
-		fixedname="$(echo "$name" | sed -e 's/^[ \t]*//')"
+		fixedname="$(echo "$name" | sed -e 's/^[ \t]//')"
 
 		if [[ -f "$path"'/'"$fixedname" ]] || [[ -d "$path"'/'"$fixedname" ]]; then
 


### PR DESCRIPTION
Line 121
From fixedname="$(echo "$name" | sed -e 's/^[ \t]*//')"
To fixedname="$(echo "$name" | sed -e 's/^[ \t]//')"