### PR TITLE
Fix sed whitespace pattern to use POSIX character class

### DIFF
--- a/scripts/fix-onedrive-filenames-apfs.sh
+++ b/scripts/fix-onedrive-filenames-apfs.sh
@@ -118,7 +118,7 @@ fix_leading_spaces() {
 		line="$(sed -n "${counter}"p "$fixlead")"
 		name="$(basename "$line")"
 		path="$(dirname "$line")"
-		fixedname="$(echo "$name" | sed -e 's/^[ \t]//')"
+		fixedname="$(echo "$name" | sed -e 's/^[[:space:]]*//')"
 
 		if [[ -f "$path"'/'"$fixedname" ]] || [[ -d "$path"'/'"$fixedname" ]]; then
 


### PR DESCRIPTION
Replace 's/^[ \t]//' with 's/^[[:space:]]*//' to use the portable POSIX character class for whitespace and remove all leading whitespace, not just one character.

https://claude.ai/code/session_017SSjgyrq8utsw4uRhWtHCH